### PR TITLE
Ignore cancelled skull click events

### DIFF
--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
@@ -189,7 +189,7 @@ public class PlayerHeadsListener implements Listener {
         }
     }
 
-    @EventHandler(priority = EventPriority.MONITOR)
+    @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
     public void onPlayerInteract(PlayerInteractEvent event) {
         Block block = event.getClickedBlock();
         Player player = event.getPlayer();


### PR DESCRIPTION
Even if the click event is cancelled, PlayerHeads still tells you to whom the head belongs. This change ignores the click if another plugin has marked it as cancelled. Block logging plugins, for instance, will cancel click events if the player is looking up logs at that location.
