### PR TITLE
Remove unnecessary dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,11 +40,6 @@
   
   <dependencies>
     <dependency>
-      <groupId>org.spigotmc</groupId>
-      <artifactId>spigot-api</artifactId>
-      <version>1.8-R0.1-SNAPSHOT</version>
-    </dependency>
-    <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
       <version>1.8-R0.1-SNAPSHOT</version>
@@ -53,6 +48,16 @@
       <groupId>fr.neatmonster</groupId>
       <artifactId>ncpplugin</artifactId>
       <version>static</version>
+      <exclusions>
+        <exclusion>
+          <groupId>org.bukkit</groupId>
+          <artifactId>bukkit</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>org.bukkit</groupId>
+          <artifactId>craftbukkit</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
   

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>bukkit</artifactId>
-      <version>1.8-R0.1-SNAPSHOT</version>
+      <version>1.10.2-R0.1-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>fr.neatmonster</groupId>
@@ -76,7 +76,7 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.0</version>
+        <version>2.2</version>
         <configuration>
           <includes>
             <include>org.bukkit</include>
@@ -98,7 +98,7 @@
       <plugin>
         <groupId>com.lukegb.mojo</groupId>
         <artifactId>gitdescribe-maven-plugin</artifactId>
-        <version>1.3</version>
+        <version>3.0</version>
         <configuration>
           <outputPrefix>-</outputPrefix>
         </configuration>
@@ -113,7 +113,7 @@
       </plugin>
       <plugin>
         <artifactId>maven-jar-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.0.2</version>
         <configuration>
           <archive>
             <manifestEntries>
@@ -129,15 +129,15 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.0.2</version>
+        <version>3.5.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
+          <source>1.8</source>
+          <target>1.8</target>
         </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>
-        <version>1.7</version>
+        <version>1.8</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -168,7 +168,7 @@
                   <pluginExecutionFilter>
                     <groupId>com.lukegb.mojo</groupId>
                     <artifactId>gitdescribe-maven-plugin</artifactId>
-                    <versionRange>[1.3,)</versionRange>
+                    <versionRange>[3.0,)</versionRange>
                     <goals>
                       <goal>gitdescribe</goal>
                     </goals>
@@ -181,7 +181,7 @@
                   <pluginExecutionFilter>
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
-                    <versionRange>[2.0,)</versionRange>
+                    <versionRange>[2.2,)</versionRange>
                     <goals>
                       <goal>use-latest-versions</goal>
                     </goals>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>org.shininet.bukkit</groupId>
   <artifactId>PlayerHeads</artifactId>
   <packaging>jar</packaging>
-  <version>3.10-SNAPSHOT</version>
+  <version>3.10</version>
   <name>PlayerHeads</name>
   
   <organization>

--- a/src/main/java/org/shininet/bukkit/playerheads/CustomSkullType.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/CustomSkullType.java
@@ -37,7 +37,7 @@ public enum CustomSkullType {
     WOLF("Pablo_Penguin", "Budwolf"), // I still need an official wolf head if anyone wants to provide one
     CAVE_SPIDER("MHF_CaveSpider"), // Thanks Marc Watson
     RABBIT("rabbit2077"), // Thanks IrParadox
-    GUARDIAN("Guardian", "creepypig7", "Creepypig7"); // Thanks lee3kfc
+    GUARDIAN("Guardian"); // Thanks lee3kfc
 
     private final String owner;
 

--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
@@ -200,8 +200,8 @@ public class PlayerHeadsListener implements Listener {
             if (player.hasPermission("playerheads.clickinfo")) {
                 switch (skullState.getSkullType()) {
                 case PLAYER:
-                    if (skullState.hasOwner()) {
-                        String owner = skullState.getOwner();
+                    String owner = skullState.getOwner();
+                    if (skullState.hasOwner() && owner != null) {
                         //String ownerStrip = ChatColor.stripColor(owner); //Unnecessary?
                         CustomSkullType skullType = CustomSkullType.get(owner);
                         if (skullType != null) {

--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
@@ -144,6 +144,8 @@ public class PlayerHeadsListener implements Listener {
             if (((Slime) event.getEntity()).getSize() == 1) {
                 EntityDeathHelper(event, CustomSkullType.SLIME, plugin.configFile.getDouble("slimedroprate") * lootingrate);
             }
+        } else if (entityType == EntityType.ENDER_DRAGON) {
+            EntityDeathHelper(event, SkullType.DRAGON, plugin.configFile.getDouble("enderdragondroprate") * lootingrate);
         } else {
             try {
                 CustomSkullType customSkullType = CustomSkullType.valueOf(entityType.name());

--- a/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
+++ b/src/main/java/org/shininet/bukkit/playerheads/PlayerHeadsListener.java
@@ -133,6 +133,9 @@ public class PlayerHeadsListener implements Listener {
             if (((Skeleton) event.getEntity()).getSkeletonType() == Skeleton.SkeletonType.NORMAL) {
                 EntityDeathHelper(event, SkullType.SKELETON, plugin.configFile.getDouble("skeletondroprate") * lootingrate);
             } else if (((Skeleton) event.getEntity()).getSkeletonType() == Skeleton.SkeletonType.WITHER) {
+                if (plugin.configFile.getDouble("witherdroprate") < 0) {
+                    return;
+                }
                 for (Iterator<ItemStack> it = event.getDrops().iterator(); it.hasNext();) {
                     if (it.next().getType() == Material.SKULL_ITEM) {
                         it.remove();


### PR DESCRIPTION
fr.neatmonster.ncpplugin has dependencies on many different versions of CraftBukkit. Maven tried to pull all of them in for a build and failed when it couldn't find them all. I've excluded it since it's not actually necessary to build.

When I was adding the exclusion, I noticed that you depend on both spigot-api and bukkit. This is redundant so I removed spigot-api. The plugin still builds but now has far fewer dependencies.
