### PR TITLE
Fix alert GHSA-269g-pwp5-87pp for junit (base).  junit 4.12->4.13.1

### DIFF
--- a/PlayerHeads-compatibility-lib/pom.xml
+++ b/PlayerHeads-compatibility-lib/pom.xml
@@ -129,7 +129,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>

--- a/PlayerHeads-core/pom.xml
+++ b/PlayerHeads-core/pom.xml
@@ -87,7 +87,7 @@
   	<dependency>
   		<groupId>junit</groupId>
   		<artifactId>junit</artifactId>
-  		<version>[4.12,)</version>
+  		<version>[4.13.1,)</version>
   		<type>jar</type>
   		<scope>test</scope>
   	</dependency>

--- a/PlayerHeads-crossversion-plugin/pom.xml
+++ b/PlayerHeads-crossversion-plugin/pom.xml
@@ -100,7 +100,7 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.12</version>
+            <version>4.13.1</version>
             <type>jar</type>
             <scope>test</scope>
         </dependency>


### PR DESCRIPTION
temporary base repo fix for GHSA-269g-pwp5-87pp
this project is fixed downstream already (56e07e6c71a34f79f259ac583fa6a860341b35a8) and a future merge will replace this fix with one applied there most likely - to no difference.

This security issue only affects users and developers building the project or running project testcases, not users of the final plugin.

this pull is being provided to push a security fix sooner rather than wait for development versions to become stable.
this PR is being made for ease of reference [and to squash these commits from the browser quickly.]

this supercedes automatic PR #20 

